### PR TITLE
Make diff_match_patch-python work with python 2 and unicode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 dist
+*.egg-info

--- a/diff_match_patch_test.py
+++ b/diff_match_patch_test.py
@@ -1,0 +1,37 @@
+import unittest
+import sys;
+
+from diff_match_patch import diff_str
+from diff_match_patch import diff_unicode
+
+def diff_str_defaults(a, b):
+  return diff_str(unicode(a), unicode(b), checklines=False, cleanup_semantic=False, counts_only=False, timelimit=0)
+
+def diff_unicode_defaults(a, b):
+  return diff_unicode(a, b, timelimit=0)
+
+class DiffMatchPatchTest(unittest.TestCase):
+  def testDiffString(self):
+    # Perform a trivial diff.
+    # Null case.
+    self.assertEquals([], diff_str_defaults("", ""))
+
+    # Equality.
+    self.assertEquals([("=", "abc")], diff_str_defaults("abc", "abc"))
+
+    # Simple insertion.
+    self.assertEquals([("=", "ab"), ("+", "123"), ("=", "c")], diff_str_defaults("abc", "ab123c"))
+
+  def testDiffUnicode(self):
+    # Perform a trivial diff.
+    # Null case.
+    self.assertEquals([], diff_unicode_defaults(u'', u''))
+
+    # # Equality.
+    self.assertEquals([("=", u'abc')], diff_unicode_defaults(u'abc', u'abc'))
+
+    # # Simple insertion.
+    self.assertEquals([("=", u'ab'), ("+", u'123'), ("=", u'c')], diff_unicode_defaults(u'abc', u'ab123c'))
+
+if __name__ == "__main__":
+  unittest.main()

--- a/diff_match_patch_test.py
+++ b/diff_match_patch_test.py
@@ -3,12 +3,13 @@ import sys;
 
 from diff_match_patch import diff_str
 from diff_match_patch import diff_unicode
+from diff_match_patch import match_main_unicode
 
 def diff_str_defaults(a, b):
-  return diff_str(unicode(a), unicode(b), checklines=False, cleanup_semantic=False, counts_only=False, timelimit=0)
+  return diff_str(unicode(a), unicode(b), checklines=True, cleanup_semantic=False, counts_only=False, timelimit=0)
 
 def diff_unicode_defaults(a, b):
-  return diff_unicode(a, b, timelimit=0)
+  return diff_unicode(a, b, checklines=True, cleanup_semantic=False, counts_only=False, timelimit=0)
 
 class DiffMatchPatchTest(unittest.TestCase):
   def testDiffString(self):
@@ -27,11 +28,24 @@ class DiffMatchPatchTest(unittest.TestCase):
     # Null case.
     self.assertEquals([], diff_unicode_defaults(u'', u''))
 
-    # # Equality.
+    # Equality.
     self.assertEquals([("=", u'abc')], diff_unicode_defaults(u'abc', u'abc'))
 
-    # # Simple insertion.
+    # Simple insertion.
     self.assertEquals([("=", u'ab'), ("+", u'123'), ("=", u'c')], diff_unicode_defaults(u'abc', u'ab123c'))
+
+  def testMatchMainUnicode(self):
+    self.assertEquals(0, match_main_unicode(u'abcdef', u'abcdef', 1000))
+
+    self.assertEquals(-1, match_main_unicode(u'', u'abcdef', 1))
+
+    self.assertEquals(3, match_main_unicode(u'abcdef', u'', 3))
+
+    self.assertEquals(3, match_main_unicode(u'abcdef', u'de', 3))
+
+    self.assertEquals(3, match_main_unicode(u'abcdef', u'defy', 4))
+
+    self.assertEquals(0, match_main_unicode(u'abcdef', u'abcdefy', 0))
 
 if __name__ == "__main__":
   unittest.main()

--- a/interface.cpp
+++ b/interface.cpp
@@ -1,5 +1,4 @@
 #include <Python.h>
-#include <iostream>
 
 #include "diff-match-patch-cpp-stl/diff_match_patch.h"
 
@@ -93,12 +92,6 @@ diff_match_patch_diff(PyObject *self, PyObject *args, PyObject *kwargs)
     return ret;
 }
 
-static PyObject *
-diff_match_patch_diff_unicode(PyObject *self, PyObject *args, PyObject *kwargs)
-{
-    return diff_match_patch_diff<const wchar_t, 'u', std::wstring, Py_UNICODE>(self, args, kwargs);
-}
-
 #if PY_MAJOR_VERSION == 2
 static PyObject *
 diff_match_patch_diff_str(PyObject *self, PyObject *args, PyObject *kwargs)
@@ -127,7 +120,7 @@ std::wstring to_wstring(Py_UNICODE* p)
     return std::wstring(buf);
 }
 
-std::string wtoa(const std::wstring& wstr)
+std::string wtos(const std::wstring& wstr)
 {
   return std::string(wstr.begin(), wstr.end());
 }
@@ -181,7 +174,7 @@ diff_match_patch_diff_unicode_python2(PyObject *self, PyObject *args, PyObject *
         PyErr_SetString(PyExc_RuntimeError, e.what());
         return NULL;
     } catch (std::wstring& s) {
-        PyErr_SetString(PyExc_RuntimeError, wtoa(s).c_str());
+        PyErr_SetString(PyExc_RuntimeError, wtos(s).c_str());
         return NULL;
     }
 
@@ -214,6 +207,7 @@ diff_match_patch_diff_unicode_python2(PyObject *self, PyObject *args, PyObject *
         PyList_Append(ret, tuple);
         Py_DECREF(tuple); // the list owns a reference now
     }
+
 
     // We're left with one extra reference.
     Py_DECREF(opcodes[dmp.DELETE]);
@@ -253,9 +247,6 @@ match_main_unicode(PyObject *self, PyObject *args, PyObject *kwargs)
     typedef diff_match_patch<std::wstring> DMP;
     DMP dmp;
 
-    // std::cout << "match_distance: " << match_distance << ", match_threshold: " << match_threshold << std::endl
-    //           << "PATTERN: " << wtoa(pattern_str) << std::endl << "TEXT: " << wtoa(text_str) << std::endl;
-
     dmp.Match_Distance = match_distance;
     dmp.Match_MaxBits = match_maxbits;
     dmp.Match_Threshold = match_threshold;
@@ -267,7 +258,7 @@ match_main_unicode(PyObject *self, PyObject *args, PyObject *kwargs)
         PyErr_SetString(PyExc_RuntimeError, e.what());
         return NULL;
     } catch (std::wstring& s) {
-        PyErr_SetString(PyExc_RuntimeError, wtoa(s).c_str());
+        PyErr_SetString(PyExc_RuntimeError, wtos(s).c_str());
         return NULL;
     }
 }

--- a/interface.cpp
+++ b/interface.cpp
@@ -37,9 +37,9 @@ diff_match_patch_diff(PyObject *self, PyObject *args, PyObject *kwargs)
                                      &timelimit, &checklines, &cleanupSemantic,
                                      &counts_only, &as_patch))
         return NULL;
-    
+
     PyObject *ret = PyList_New(0);
-    
+
     typedef diff_match_patch<CPPTYPE> DMP;
     DMP dmp;
 
@@ -47,7 +47,7 @@ diff_match_patch_diff(PyObject *self, PyObject *args, PyObject *kwargs)
     opcodes[dmp.DELETE] = PyString_FromString("-");
     opcodes[dmp.INSERT] = PyString_FromString("+");
     opcodes[dmp.EQUAL] = PyString_FromString("=");
-    
+
     dmp.Diff_Timeout = timelimit;
     typename DMP::Diffs diff = dmp.diff_main(a, b, checklines);
 
@@ -88,7 +88,7 @@ diff_match_patch_diff(PyObject *self, PyObject *args, PyObject *kwargs)
     Py_DECREF(opcodes[dmp.DELETE]);
     Py_DECREF(opcodes[dmp.INSERT]);
     Py_DECREF(opcodes[dmp.EQUAL]);
-    
+
     return ret;
 }
 
@@ -105,8 +105,109 @@ diff_match_patch_diff_str(PyObject *self, PyObject *args, PyObject *kwargs)
     return diff_match_patch_diff<const char, 's', std::string, char*>(self, args, kwargs);
 }
 
+// return the length of a null terminated character sequence
+template <class char_t> static int len(const char_t* p)
+{
+  for (int i = 0; ; i++) {
+    if (p[i] == 0) {
+      return i;
+    }
+  }
+}
+
+// convert Py_UNICODE* to std::wstring object
+std::wstring to_wstring(Py_UNICODE* p)
+{
+    int n = len(p);
+    wchar_t buf[n + 1];
+    PyUnicodeObject* obj = reinterpret_cast<PyUnicodeObject*>(PyUnicode_FromUnicode(p, n));
+    PyUnicode_AsWideChar(obj, buf, n + 1);
+    Py_DECREF(obj);
+    return std::wstring(buf);
+}
+
+static PyObject *
+diff_match_patch_diff_unicode_python2(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    Py_UNICODE *a, *b;
+    float timelimit = 0.0;
+    int checklines = 1;
+    int cleanupSemantic = 1;
+    int counts_only = 1;
+    int as_patch = 0;
+
+    static char *kwlist[] = {
+        strdup("left_document"),
+        strdup("right_document"),
+        strdup("timelimit"),
+        strdup("checklines"),
+        strdup("cleanup_semantic"),
+        strdup("counts_only"),
+        strdup("as_patch"),
+        NULL };
+
+    const char* format_spec = "uu|fbbbb";
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, format_spec, kwlist,
+                                     &a, &b,
+                                     &timelimit, &checklines, &cleanupSemantic,
+                                     &counts_only, &as_patch))
+        return NULL;
+
+    PyObject *ret = PyList_New(0);
+
+    typedef diff_match_patch<std::wstring> DMP;
+    DMP dmp;
+
+    PyObject *opcodes[3];
+    opcodes[dmp.DELETE] = PyString_FromString("-");
+    opcodes[dmp.INSERT] = PyString_FromString("+");
+    opcodes[dmp.EQUAL] = PyString_FromString("=");
+
+    dmp.Diff_Timeout = timelimit;
+
+    std::wstring a_str = to_wstring(a);
+    std::wstring b_str = to_wstring(b);
+
+    DMP::Diffs diff = dmp.diff_main(a_str, b_str, checklines);
+
+    if (cleanupSemantic)
+        dmp.diff_cleanupSemantic(diff);
+
+    if (as_patch) {
+        DMP::Patches patch = dmp.patch_make(a_str, diff);
+        std::wstring patch_str = dmp.patch_toText(patch);
+
+        return PyUnicode_FromUnicode((Py_UNICODE*)patch_str.data(), patch_str.size());
+    }
+
+    std::list<DMP::Diff>::const_iterator entryiter;
+    for (entryiter = diff.begin(); entryiter != diff.end(); entryiter++) {
+        DMP::Diff entry = *entryiter;
+        PyObject* tuple = PyTuple_New(2);
+
+        Py_INCREF(opcodes[entry.operation]); // we're going to reuse the object, so don't let SetItem steal the reference
+        PyTuple_SetItem(tuple, 0, opcodes[entry.operation]);
+
+        if (counts_only)
+            PyTuple_SetItem(tuple, 1, PyInt_FromLong(entry.text.length()));
+
+        PyObject* obj = PyUnicode_FromWideChar(entry.text.data(), entry.text.size());
+        PyTuple_SetItem(tuple, 1, obj);
+
+        PyList_Append(ret, tuple);
+        Py_DECREF(tuple); // the list owns a reference now
+    }
+
+    // We're left with one extra reference.
+    Py_DECREF(opcodes[dmp.DELETE]);
+    Py_DECREF(opcodes[dmp.INSERT]);
+    Py_DECREF(opcodes[dmp.EQUAL]);
+
+    return ret;
+}
+
 static PyMethodDef MyMethods[] = {
-    {"diff_unicode", (PyCFunction)diff_match_patch_diff_unicode, METH_VARARGS|METH_KEYWORDS,
+    {"diff_unicode", (PyCFunction)diff_match_patch_diff_unicode_python2, METH_VARARGS|METH_KEYWORDS,
     "Compute the difference between two Unicode strings. Returns a list of tuples (OP, LEN)."},
     {"diff_str", (PyCFunction)diff_match_patch_diff_str, METH_VARARGS|METH_KEYWORDS,
     "Compute the difference between two (regular) strings. Returns a list of tuples (OP, LEN)."},

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.rst

--- a/setup.py
+++ b/setup.py
@@ -9,15 +9,15 @@ module1 = Extension('diff_match_patch',
                     libraries = [])
 
 setup (
-	name='diff_match_patch_python',
-	version='1.0.1',
+        name='diff_match_patch_python_python2_fork',
+        version='1.0.1',
     packages = find_packages(),
-	author=u'Joshua Tauberer',
-	author_email=u'jt@occams.info',
-	url='https://github.com/JoshData/diff_match_patch-python',
+        author=u'Joshua Tauberer, Steve Molitor',
+        author_email=u'stevemolitor@gmail.com',
+        url='https://github.com/zapier/diff_match_patch-python',
     license='CC0 (copyright waived)',
-	description=u'A Python extension module that wraps Google\'s diff_match_patch C++ implementation for very fast string comparisons.',
+        description=u'A Python extension module that wraps Google\'s diff_match_patch C++ implementation for very fast string comparisons.',
     long_description=open("README.rst").read(),
     keywords = "diff compare Google match patch diff_match_patch extension native C fast",
-	ext_modules = [module1],
-	)
+        ext_modules = [module1],
+        )

--- a/test.py
+++ b/test.py
@@ -1,6 +1,7 @@
-import sys;
-from diff_match_patch import diff_str
 from diff_match_patch import diff_unicode
+from diff_match_patch import diff_str
+from diff_match_patch import match_main_unicode
 
-print diff_str("abc", "ab123c", counts_only=False, cleanup_semantic=False, checklines=False)
-print diff_unicode(u'abc', u'ab123c', counts_only=False, cleanup_semantic=False, checklines=False)
+#print diff_unicode(u'abc', u'ab123c', counts_only=True, cleanup_semantic=False, checklines=True)
+#print diff_str('abc', 'ab123c', 3)
+print match_main_unicode(u'abcdef', u'de', 3)

--- a/test.py
+++ b/test.py
@@ -4,4 +4,5 @@ from diff_match_patch import match_main_unicode
 
 #print diff_unicode(u'abc', u'ab123c', counts_only=True, cleanup_semantic=False, checklines=True)
 #print diff_str('abc', 'ab123c', 3)
-print match_main_unicode(u'abcdef', u'de', 3)
+match_threshold = 1.0
+print match_main_unicode(u'abcdef', u'de', 3, match_distance=200, match_threshold=match_threshold)

--- a/test.py
+++ b/test.py
@@ -1,35 +1,6 @@
-import sys
-import diff_match_patch
+import sys;
+from diff_match_patch import diff_str
+from diff_match_patch import diff_unicode
 
-if sys.version_info[0] == 3:
-	diff = diff_match_patch.diff
-	diff_bytes = diff_match_patch.diff_bytes
-else:
-	diff = diff_match_patch.diff_unicode
-	diff_bytes = diff_match_patch.diff_str
-
-def test(text1, text2, diff_function):
-	print(diff_function.__name__)
-	print("-" * len(diff_function.__name__))
-	print ("<", repr(text1))
-	print (">", repr(text2))
-	print()
-
-	print (diff_function(text1, text2, checklines=False, cleanup_semantic=True, as_patch=True))
-	print()
-
-	changes = diff_function(
-		text1, text2,
-		timelimit=15,
-		checklines=False,
-		cleanup_semantic=True,
-		counts_only=False)
-
-	for op, text in changes:
-		print(op, repr(text))
-
-	print ("")
-
-test(u"this is a test", u"this program is not \u2192 a test", diff)
-test(b"this is a test", b"this program is not ==> a test", diff_bytes)
-	
+print diff_str("abc", "ab123c", counts_only=False, cleanup_semantic=False, checklines=False)
+print diff_unicode(u'abc', u'ab123c', counts_only=False, cleanup_semantic=False, checklines=False)


### PR DESCRIPTION
WIP
- fixed `diff_unicode` for python 2
- added `match_main` for python 2

example: https://github.com/zapier/diff_match_patch-python/blob/python-2-unicode-support/test.py
unit test: https://github.com/zapier/diff_match_patch-python/blob/python-2-unicode-support/diff_match_patch_test.py

@bryanhelmig 
